### PR TITLE
fix: `CommandRecord.trim` raises `OverflowError` instead of `S2ClientError`

### DIFF
--- a/src/s2_sdk/_types.py
+++ b/src/s2_sdk/_types.py
@@ -272,6 +272,7 @@ class CommandRecord:
         return Record(body=encoded_token, headers=[(bytes(), CommandRecord.FENCE)])
 
     @staticmethod
+    @fallible
     def trim(desired_first_seq_num: int) -> Record:
         """Create a trim command record.
 


### PR DESCRIPTION
closes https://github.com/s2-streamstore/s2-sdk-python/issues/8