### PR TITLE
feat: use `a.s2.dev` as the default account endpoint

### DIFF
--- a/src/s2_sdk/_types.py
+++ b/src/s2_sdk/_types.py
@@ -76,7 +76,7 @@ class Endpoints:
     def default(cls) -> Endpoints:
         """Construct default S2 cloud endpoints."""
         return cls(
-            account="https://aws.s2.dev",
+            account="https://a.s2.dev",
             basin="https://{basin}.b.s2.dev",
         )
 


### PR DESCRIPTION
Changes the default account endpoint from `https://aws.s2.dev` to `https://a.s2.dev` in `Endpoints.default()`. `aws.s2.dev` continues to serve, so existing configurations are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)