### PR TITLE
fix: uncaught `asyncio.CancelledError` in `Connection.send_headers`

### DIFF
--- a/src/s2_sdk/_client.py
+++ b/src/s2_sdk/_client.py
@@ -686,7 +686,7 @@ class Connection:
             try:
                 self._h2.send_headers(stream_id, headers, end_stream=end_stream)
                 await self._flush_h2_data_and_drain()
-            except Exception:
+            except (asyncio.CancelledError, Exception):
                 self._streams.pop(stream_id, None)
                 raise
             return stream_id


### PR DESCRIPTION
closes #81 