### PR TITLE
fix: prevent orphaned connections in checkout/close race

### DIFF
--- a/src/s2_sdk/_client.py
+++ b/src/s2_sdk/_client.py
@@ -331,6 +331,8 @@ class ConnectionPool:
             self._host_locks[base_url] = lock
 
         async with lock:
+            if self._closed:
+                raise S2ClientError("Pool is closed")
             # Re-check after acquiring lock — another caller may have
             # created a connection while we waited.
             result = self._try_checkout(base_url)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -126,6 +126,36 @@ async def test_closed_pool_raises(pool: ConnectionPool):
 
 
 @pytest.mark.asyncio
+async def test_checkout_racing_close_does_not_orphan_connection(pool: ConnectionPool):
+    """A checkout() blocked waiting on the per-host lock must not create or
+    register a connection if close() completes while it was waiting.
+
+    Regression test: checkout() only checked `_closed` before acquiring the
+    per-host lock, not after. A caller could pass that initial check, then
+    block on the lock while a concurrent close() ran to completion, then
+    acquire the lock and still create a connection — leaving it registered
+    in a "closed" pool with its socket and background recv task never
+    cleaned up.
+    """
+    base_url = "https://example.com"
+    lock = asyncio.Lock()
+    pool._host_locks[base_url] = lock
+    await lock.acquire()  # Simulate the lock being held by another caller.
+
+    with patch("s2_sdk._client.Connection", return_value=_mock_connection()):
+        task = asyncio.create_task(pool.checkout(base_url))
+        await asyncio.sleep(0)  # Let the task block on lock acquisition.
+
+        await pool.close()
+        lock.release()  # The blocked checkout can now proceed.
+
+        with pytest.raises(S2ClientError, match="Pool is closed"):
+            await task
+
+    assert pool._hosts == {}
+
+
+@pytest.mark.asyncio
 async def test_dead_connection_not_reused(pool: ConnectionPool):
     """A connection whose recv_loop has died should not be reused."""
     with patch("s2_sdk._client.Connection") as MockConn:


### PR DESCRIPTION
checkout() only checked self._closed before acquiring the per-host lock. A caller could pass that check, then block on the lock while a concurrent close() ran to completion, then still create and register a connection after the pool was closed - leaking a socket and its background recv task.

Add a re-check of self._closed immediately after acquiring the lock.

Fixes #97

## Validation

- Added `test_checkout_racing_close_does_not_orphan_connection`, which deterministically triggers the race by holding the per-host lock while `close()` runs, rather than relying on timing/sleeps
- Full suite: `uv run --group test pytest tests/test_client.py -v` — 35/35 passed
- `ruff format --check` and `ruff check` — clean
- `mypy` — no issues found